### PR TITLE
Fixes JSONDecodeError in OnPrem setups.

### DIFF
--- a/shuffle_sdk/shuffle_sdk.py
+++ b/shuffle_sdk/shuffle_sdk.py
@@ -2597,7 +2597,6 @@ class AppBase:
 
                     # Checks specific regex like #1-2 for index 1-2 in a loop
                     elif len(actualitem) > 0:
-
                         is_loop = True
                         newvalue = []
                         firstitem = actualitem[0][0]
@@ -2684,7 +2683,15 @@ class AppBase:
                                             pass
 
                                 except json.decoder.JSONDecodeError as e:
-                                    return str(basejson[value]), False
+                                    if "Expecting value: line 1 column 2" in str(e):
+                                        try:
+                                            self.logger.info(f"[WARNING] Failed to load json object trying different approach")
+                                            obj = ast.literal_eval(basejson[value])
+                                            basejson = obj if isinstance(obj, (dict, list)) else json.loads(json.dumps(obj))
+                                        except:
+                                            return str(basejson[value]), False
+                                    else:
+                                        return str(basejson[value]), False
                             else:
                                 basejson = basejson[value]
                         except KeyError as e:


### PR DESCRIPTION
If we do something like `print([str(i) for i in range(10)])` 

this returns a list which looks like this: 
`['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']`

Now the problem is if we do `json.loads()` to this string (this is treaded as str in app_sdk), it throws an exception because the input string like `['1','2']` is not valid JSON — it's a Python-style list, not JSON-compliant.

Hence a case where we can handle such problem and fix it for the user. Now this exist only in OnPrem not sure how but cloud setup automatically converts this: `'1'` to this: `"1"` (probably frontend?).