### PR TITLE
Fix: Normalize 'runtime' variable to treat 'swarm' as 'run'

### DIFF
--- a/shuffle_sdk/shuffle_sdk.py
+++ b/shuffle_sdk/shuffle_sdk.py
@@ -33,6 +33,8 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 runtime = os.getenv("SHUFFLE_SWARM_CONFIG", "")
+if runtime == "swarm":
+    runtime = "run"
 
 ###
 ###


### PR DESCRIPTION
--- LLM slop. But this works.

In `shuffle_sdk.py`, the `runtime` variable can be initialized from the `SHUFFLE_SWARM_CONFIG` environment variable. You reported that this variable can have the value 'swarm' or 'run', and both should be treated as the same.

I've added a normalization step immediately after reading the environment variable. If the `runtime` variable is 'swarm', it is changed to 'run'. This ensures that all subsequent code that checks for `runtime == 'run'` will behave consistently, regardless of which of the two values you provide in the environment.